### PR TITLE
Forced Directions

### DIFF
--- a/js/kenburns.js
+++ b/js/kenburns.js
@@ -3,19 +3,19 @@
  * Original author: John [at] Toymakerlabs
  * Further changes, comments: [at]Toymakerlabs
  * Licensed under the MIT license
- * 
+ *
  * Copyright (c) 2013 ToymakerLabs
 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute, 
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
- * furnished to do so, subject to the following conditions: The above copyright notice and this 
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions: The above copyright notice and this
  * permission notice shall be included in all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
- * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
  * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
@@ -32,6 +32,7 @@
             fadeSpeed:500,
             scale:1,
             ease3d:'cubic-bezier(.81, 0, .26, 1)',
+            forceDirection:null,
             onLoadingComplete:function(){},
             onSlideComplete:function(){},
             onListComplete:function(){},
@@ -49,7 +50,7 @@
         this._defaults = defaults;
         this._name = pluginName;
         this.maxSlides = this.options.images.length;
-        
+
         this.init();
     }
 
@@ -58,7 +59,7 @@
     ------------------------------------------------------------------------------------------------- */
     /**
      * Init
-     * Initial setup - dermines width, height, and adds the loading icon. 
+     * Initial setup - dermines width, height, and adds the loading icon.
      */
     Plugin.prototype.init = function () {
 
@@ -74,7 +75,7 @@
             imagesObj["image"+i] = {};
             imagesObj["image"+i].loaded = false;
         	this.attachImage(list[i], "image"+i , i);
-        	
+
         }
 
         var loader = $('<div/>');
@@ -87,13 +88,13 @@
 
     /*  2. Loading and Setup
     ------------------------------------------------------------------------------------------------- */
-   
+
     /**
      * Attach image
      * creates a wrapper div for the image along with the image tag. The reason for the additional
      * wrapper is that we are transitioning multiple properties at the same time: scale, position, and
      * opacity. But we want opacity to finish first. This function also determines if the browser
-     * has 3d transform capabilities and initializes the starting CSS values. 
+     * has 3d transform capabilities and initializes the starting CSS values.
      */
     Plugin.prototype.attachImage = function(url,alt_text,index) {
     	var that = this;
@@ -147,7 +148,7 @@
 
         }
 
-        //if the next image hasnt loaded yet, but the transition has started, 
+        //if the next image hasnt loaded yet, but the transition has started,
         // this will match the image index to the image holding the transition.
         // it will then resume the transition.
         if(index == this.holdup) {
@@ -169,7 +170,7 @@
         }
     }
 
-    //if any of the slides are not loaded, the set has not finished loading. 
+    //if any of the slides are not loaded, the set has not finished loading.
     Plugin.prototype.checkLoadProgress = function() {
         var imagesLoaded = true;
          for(i=0;i<this.maxSlides;i++){
@@ -183,7 +184,7 @@
     /**
      * Wait
      * Stops the transition interval, shows the loader and
-     * applies the stalled class to the visible image. 
+     * applies the stalled class to the visible image.
      */
     Plugin.prototype.wait = function() {
         clearInterval(this.interval);
@@ -204,7 +205,7 @@
      * startTransition
      * Begins the Gallery Transition and tracks the current slide
      * Also manages loading - if the interval encounters a slide
-     * that has not loaded, the transition pauses. 
+     * that has not loaded, the transition pauses.
      */
 	Plugin.prototype.startTransition = function(start_index) {
 	    var that = this;
@@ -219,13 +220,13 @@
             }else {
                 currentSlide = 0;
             }
-            
+
             //Check if the next slide is loaded. If not, wait.
             if(imagesObj["image"+currentSlide].loaded == false){
                 that.holdup = currentSlide;
                 that.wait();
 
-            //if the next slide is loaded, go ahead and do the transition. 
+            //if the next slide is loaded, go ahead and do the transition.
             }else {
                 that.doTransition();
             }
@@ -234,15 +235,15 @@
 	}
 
 
-    /** 
+    /**
     * chooseCorner
     * This function chooses a random start corner and a random end corner
     * that is different from the start. This gives a random direction effect
-    * it returns coordinates used by the transition functions. 
+    * it returns coordinates used by the transition functions.
     */
-   
+
     Plugin.prototype.chooseCorner = function() {
-        var scale = this.options.scale; 
+        var scale = this.options.scale;
         var image = imagesObj["image"+currentSlide].element;
 
         var ratio = image.height/image.width;
@@ -264,13 +265,35 @@
             {x:1,y:1}
         ];
 
-        //Pick the first corner. Remove it from the array 
+        var forcedDirections = {
+            "horizontal" : {
+                0 : 1,
+                1 : 0,
+                2 : 3,
+                3 : 2
+            },
+            "vertical" : {
+                0 : 2,
+                1 : 3,
+                2 : 0,
+                3 : 1
+            }
+        };
+
+        //Pick the first corner. Remove it from the array
         var choice = Math.floor(Math.random()*4);
         var start = corners[choice];
+        var end = null;
 
         //Pick the second corner from the subset
-        corners.splice(choice,1);
-        var end = corners[Math.floor(Math.random()*3)];
+
+        if(!this.options.forceDirection){
+            corners.splice(choice, 1);
+            var end = corners[Math.floor(Math.random()*3)];
+        }
+        else{
+            var end = corners[forcedDirections[this.options.forceDirection][choice]];
+        }
 
         //build the new coordinates from the chosen coordinates
         var coordinates = {
@@ -288,7 +311,7 @@
 
 
 
-    /** 
+    /**
     *  Transiton3D
     *  Transition3d Function works by setting the webkit and moz translate3d properties. These
     *  are hardware accellerated and give a very smooth animation. Since only one animation
@@ -298,7 +321,7 @@
 
     Plugin.prototype.transition3d = function () {
         var that  = this;
-        var scale = this.options.scale; 
+        var scale = this.options.scale;
         var image = imagesObj["image"+currentSlide].element;
         var position = this.chooseCorner();
 
@@ -329,16 +352,16 @@
 
     /**
      *  Transition
-     *  The regular JQuery animation function. Sets the currentSlide initial scale and position to 
+     *  The regular JQuery animation function. Sets the currentSlide initial scale and position to
      *  the value from chooseCorner before triggering the animation. It starts the image moving to
      *  the new position, starts the fade on the wrapper, and delays the fade out animation. Adding
      *  fadeSpeed to duration gave me a nice crossfade so the image continues to move as it fades out
-     *  rather than just stopping.  
+     *  rather than just stopping.
      */
 
     Plugin.prototype.transition = function() {
         var that  = this;
-        var scale = this.options.scale; 
+        var scale = this.options.scale;
         var image = imagesObj["image"+currentSlide].element;
         var sw = $(image).width();
         var sh = $(image).height();
@@ -346,7 +369,7 @@
 
         $(image).css({'left':position.startX,'top':position.startY,'width':sw*(scale),'height':sh*(scale)});
         $(image).animate({'left':position.endX,'top':position.endY,'width':sw,'height':sh}, that.options.duration + that.options.fadeSpeed);
-        
+
         $(image).parent().css({'opacity':0,'z-index':3});
         $(image).parent().animate({'opacity':1},that.options.fadeSpeed);
 
@@ -367,14 +390,14 @@
 
     /* 4. Utility Functions
     ------------------------------------------------------------------------------------------------- */
-    /** 
+    /**
      *  has3DTransforms
      *  Tests the browser to determine support for Webkit and Moz Transforms
      *  Creates an element, translates the element, and tests the values. If the
-     *  values return true, the browser supports 3D transformations. 
+     *  values return true, the browser supports 3D transformations.
      */
     function has3DTransforms() {
-        var el = document.createElement('p'), 
+        var el = document.createElement('p'),
             has3d,
             transforms = {
                 'WebkitTransform':'-webkit-transform',
@@ -394,7 +417,7 @@
         return (has3d !== undefined && has3d.length > 0 && has3d !== "none");
     }
 
-    /** 
+    /**
      *  insertAt
      *  Utility function that inserts objects at a specific index
      *  Used to maintain the order of images as they are loaded and
@@ -414,7 +437,7 @@
     $.fn[pluginName] = function ( options ) {
         return this.each(function () {
             if (!$.data(this, 'plugin_' + pluginName)) {
-                $.data(this, 'plugin_' + pluginName, 
+                $.data(this, 'plugin_' + pluginName,
                 new Plugin( this, options ));
             }
         });


### PR DESCRIPTION
I want to start off by saying this is my first time suggesting a file edit to a repository I'm not involved in, and that I'm relatively new to programming as an occupation, so please do let me know if you think I've done anything in a 'newbie' way. I'm very happy to be corrected and learn.

Thank you so much for writing this Javascript library, it's been really great. However if you want the slide show to cover a client's whole screen, a problem can crop up with parts of the photo disproportionately outside of its border. A laptop screen for example can wind up expanding the photo to fit the width, and then having a chunk of the picture outside the border vertically. This means when your kenburns.js gets to work the vertical movements will be much faster than the horizontal movements.

The fix I've gone for is adding the option to force movements to be either wholly vertical or horizontal. If you want to use that option you just set the `forceDirection` variable to either 'horizontal' or 'vertical' when initialising the Plugin on an element.
